### PR TITLE
Documentation cleanup

### DIFF
--- a/cmd/construct_test.go
+++ b/cmd/construct_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/renv_test.go
+++ b/cmd/renv_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package cmd implements the core functionality of locksmith - the renv.lock generator.
 package cmd
 
 import (

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
-// Package locksmith is the main package of locksmith - the renv.lock generator.
-package locksmith
+// Package main is the main package of locksmith - the renv.lock generator.
+package main
 
 import "github.com/insightsengineering/locksmith/cmd"
 

--- a/main.go
+++ b/main.go
@@ -1,4 +1,5 @@
-package main
+// Package locksmith is the main package of locksmith - the renv.lock generator.
+package locksmith
 
 import "github.com/insightsengineering/locksmith/cmd"
 


### PR DESCRIPTION
This should remove the repeated contents of license from [here](https://pkg.go.dev/github.com/insightsengineering/locksmith@v0.1.0/cmd#pkg-overview) and add the information about `locksmith` package [here](https://pkg.go.dev/github.com/insightsengineering/locksmith@v0.1.0#section-documentation).