### PR TITLE
Allow incomplete renv.lock

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,11 +10,11 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      # - darwin
-      # - windows
+      - darwin
+      - windows
     goarch:
       - amd64
-      # - arm64
+      - arm64
     ldflags:
       - -s -w
       - -X go.szostok.io/version.version={{.Version}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,11 +10,11 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - darwin
-      - windows
+      # - darwin
+      # - windows
     goarch:
       - amd64
-      - arm64
+      # - arm64
     ldflags:
       - -s -w
       - -X go.szostok.io/version.version={{.Version}}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ repositories (e.g. in a package manager, CRAN, BioConductor etc.), `locksmith` w
 the list of all dependencies and their versions required to make the input list of packages work.
 It will then save the result in an `renv.lock`-compatible file.
 
+For additional information about `renv.lock`, please refer to the [`renv` documentation](https://rstudio.github.io/renv/articles/renv.html).
+
 ## Installation
 
 Simply download the project for your distribution from the

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For additional information about `renv.lock`, please refer to the [`renv` docume
 
 Simply download the project for your distribution from the
 [releases](https://github.com/insightsengineering/locksmith/releases) page. `locksmith` is
-distributed as a single binary file and does not require any additional system requirements.
+distributed as a single binary file and does not need any additional system requirements.
 
 Alternatively, you can install the latest version by running:
 
@@ -46,7 +46,7 @@ easily in a configuration file.
 locksmith --inputPackageList https://raw.githubusercontent.com/insightsengineering/formatters/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/rtables/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/scda/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/scda.2022/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/nestcolor/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/tern/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/rlistings/main/DESCRIPTION,https://gitlab.example.com/projectgroup/projectsubgroup/projectname/-/raw/main/DESCRIPTION --inputRepositoryList BioC=https://bioconductor.org/packages/release/bioc,CRAN=https://cran.rstudio.com
 ```
 
-In order to download the packages from GitHub or GitLab repositories, please set the environment
+In order to download the packages from non-public GitHub or GitLab repositories, please set the environment
 variables containing the Personal Access Tokens.
 
 * For GitHub, set the `LOCKSMITH_GITHUBTOKEN` environment variable.
@@ -87,10 +87,20 @@ as opposed to `inputPackageList` and `inputRepositoryList` CLI flags/YAML keys.
 Additionally, `inputPackageList`/`inputRepositoryList` CLI flags take precendence over
 `inputPackages`/`inputRepositories` YAML keys.
 
+## Environment variables
+
+`locksmith` reads environment variables with `LOCKSMITH_` prefix and tries to match them with CLI
+flags. For example, setting the following variables will override the respective values from the
+configuration file: `LOCKSMITH_LOGLEVEL`, `LOCKSMITH_INPUTPACKAGELIST`, `LOCKSMITH_INPUTREPOSITORYLIST` etc.
+
+The order of precedence is:
+
+CLI flag → environment variable → configuration file → default value.
+
 ## Binary dependencies
 
 For `locksmith` in order to generate an `renv.lock` with binary R packages,
-it is necessary to provide URLs to binary repositories in `inputRepositories`/`inputRepositoryList`.
+it is necessary to provide URLs to binary repositories via `inputRepositories`/`inputRepositoryList`.
 
 Examples illustrating the expected format of URLs to repositories with binary packages:
 
@@ -140,16 +150,6 @@ Simply list the types of dependencies which should not cause the `renv.lock` gen
 ```bash
 locksmith --allowIncompleteRenvLock 'Imports,Depends,Suggests,LinkingTo'
 ```
-
-## Environment variables
-
-`locksmith` reads environment variables with `LOCKSMITH_` prefix and tries to match them with CLI
-flags. For example, setting the following variables will override the respective values from the
-configuration file: `LOCKSMITH_LOGLEVEL`, `LOCKSMITH_EXAMPLEPARAMETER` etc.
-
-The order of precedence is:
-
-CLI flag → environment variable → configuration file → default value.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@
 
 `locksmith` is a utility to generate `renv.lock` file containing all dependencies of given set of R packages.
 
-Given the input list of git repositories containing the R packages, as well as a list of R package repositories (e.g. in a package manager, CRAN, BioConductor etc.), `locksmith` will try to determine the list of all dependencies and their versions required to make the input list of packages work. It will then save the result in an `renv.lock`-compatible file.
+Given the input list of git repositories containing the R packages, as well as a list of R package
+repositories (e.g. in a package manager, CRAN, BioConductor etc.), `locksmith` will try to determine
+the list of all dependencies and their versions required to make the input list of packages work.
+It will then save the result in an `renv.lock`-compatible file.
 
 ## Installation
 
-Simply download the project for your distribution from the [releases](https://github.com/insightsengineering/locksmith/releases) page. `locksmith` is distributed as a single binary file and does not require any additional system requirements.
+Simply download the project for your distribution from the
+[releases](https://github.com/insightsengineering/locksmith/releases) page. `locksmith` is
+distributed as a single binary file and does not require any additional system requirements.
 
 Alternatively, you can install the latest version by running:
 
@@ -18,7 +23,8 @@ go install github.com/insightsengineering/locksmith@latest
 
 ## Usage
 
-`locksmith` is a command line utility, so after installing the binary in your `PATH`, simply run the following command to view its capabilities:
+`locksmith` is a command line utility, so after installing the binary in your `PATH`,simply run the
+following command to view its capabilities:
 
 ```bash
 locksmith --help
@@ -31,13 +37,15 @@ locksmith --logLevel debug --exampleParameter 'exampleValue'
 ```
 
 Real-life example with multiple input packages and repositories.
-Please see below for [an example](#configuration-file) how to set package and repository lists more easily in a configuration file.
+Please see below for [an example](#configuration-file) how to set package and repository lists more
+easily in a configuration file.
 
 ```bash
-locksmith --inputPackageList https://raw.githubusercontent.com/insightsengineering/formatters/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/rtables/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/scda/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/scda.2022/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/nestcolor/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/tern/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/rlistings/main/DESCRIPTION --inputRepositoryList BioC=https://bioconductor.org/packages/release/bioc,CRAN=https://cran.rstudio.com
+locksmith --inputPackageList https://raw.githubusercontent.com/insightsengineering/formatters/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/rtables/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/scda/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/scda.2022/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/nestcolor/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/tern/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/rlistings/main/DESCRIPTION,https://gitlab.example.com/projectgroup/projectsubgroup/projectname/-/raw/main/DESCRIPTION --inputRepositoryList BioC=https://bioconductor.org/packages/release/bioc,CRAN=https://cran.rstudio.com
 ```
 
-In order to download the packages from GitHub or GitLab repositories, please set the environment variables containing the Personal Access Tokens.
+In order to download the packages from GitHub or GitLab repositories, please set the environment
+variables containing the Personal Access Tokens.
 
 * For GitHub, set the `LOCKSMITH_GITHUBTOKEN` environment variable.
 * For GitLab, set the `LOCKSMITH_GITLABTOKEN` environment variable.
@@ -46,12 +54,15 @@ By default `locksmith` will save the resulting output file to `renv.lock`.
 
 ## Configuration file
 
-If you'd like to set the above options in a configuration file, by default `locksmith` checks `~/.locksmith`, `~/.locksmith.yaml` and `~/.locksmith.yml` files.
+If you'd like to set the above options in a configuration file, by default `locksmith` checks
+`~/.locksmith`, `~/.locksmith.yaml` and `~/.locksmith.yml` files.
 
-If any of these files exist, `locksmith` will use options defined there, unless they are overridden by command line flags or environment variables.
+If any of these files exist, `locksmith` will use options defined there, unless they are overridden
+by command line flags or environment variables.
 
-You can also specify custom path to configuration file with `--config <your-configuration-file>.yml` command line flag.
-When using custom configuration file, if you specify command line flags, the latter will still take precedence.
+You can also specify custom path to configuration file with `--config <your-configuration-file>.yml`
+command line flag. When using custom configuration file, if you specify command line flags,
+the latter will still take precedence.
 
 Example contents of configuration file:
 
@@ -62,6 +73,7 @@ inputPackages:
   - https://raw.githubusercontent.com/insightsengineering/rtables/main/DESCRIPTION
   - https://raw.githubusercontent.com/insightsengineering/scda/main/DESCRIPTION
   - https://raw.githubusercontent.com/insightsengineering/scda.2022/main/DESCRIPTION
+  - https://gitlab.example.com/projectgroup/projectsubgroup/projectname/-/raw/main/DESCRIPTION
 inputRepositories:
   - Bioconductor.BioCsoft=https://bioconductor.org/packages/release/bioc
   - CRAN=https://cran.rstudio.com
@@ -70,11 +82,13 @@ inputRepositories:
 The example above shows an alternative way of providing input packages, and input repositories,
 as opposed to `inputPackageList` and `inputRepositoryList` CLI flags/YAML keys.
 
-Additionally, `inputPackageList`/`inputRepositoryList` CLI flags take precendence over `inputPackages`/`inputRepositories` YAML keys.
+Additionally, `inputPackageList`/`inputRepositoryList` CLI flags take precendence over
+`inputPackages`/`inputRepositories` YAML keys.
 
 ## Binary dependencies
 
-For `locksmith` in order to generate an `renv.lock` with binary R packages, it is necessary to provide URLs to binary repositories in `inputRepositories`/`inputRepositoryList`.
+For `locksmith` in order to generate an `renv.lock` with binary R packages,
+it is necessary to provide URLs to binary repositories in `inputRepositories`/`inputRepositoryList`.
 
 Examples illustrating the expected format of URLs to repositories with binary packages:
 
@@ -113,11 +127,23 @@ As a result, the configuration file could look like this:
       - Bioc-Windows=https://www.bioconductor.org/packages/release/bioc/bin/windows/contrib/4.3
     ```
 
+## Packages not found in the repositories
+
+It may happen that some of the dependencies required by the input packages cannot be found in any of
+the input repositories. By default, `locksmith` will fail in such case and show a list of such dependencies.
+
+However, it is possible to override this behavior by using the `--allowIncompleteRenvLock` flag.
+Simply list the types of dependencies which should not cause the `renv.lock` generation to fail:
+
+```bash
+locksmith --allowIncompleteRenvLock 'Imports,Depends,Suggests,LinkingTo'
+```
+
 ## Environment variables
 
-`locksmith` reads environment variables with `LOCKSMITH_` prefix and tries to match them with CLI flags.
-For example, setting the following variables will override the respective values from configuration file:
-`LOCKSMITH_LOGLEVEL`, `LOCKSMITH_EXAMPLEPARAMETER` etc.
+`locksmith` reads environment variables with `LOCKSMITH_` prefix and tries to match them with CLI
+flags. For example, setting the following variables will override the respective values from the
+configuration file: `LOCKSMITH_LOGLEVEL`, `LOCKSMITH_EXAMPLEPARAMETER` etc.
 
 The order of precedence is:
 
@@ -129,7 +155,9 @@ This project is built with the [Go programming language](https://go.dev/).
 
 ### Development Environment
 
-It is recommended to use Go 1.21+ for developing this project. This project uses a pre-commit configuration and it is recommended to [install and use pre-commit](https://pre-commit.com/#install) when you are developing this project.
+It is recommended to use Go 1.21+ for developing this project. This project uses a pre-commit
+configuration and it is recommended to [install and use pre-commit](https://pre-commit.com/#install)
+when you are developing this project.
 
 ### Common Commands
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ go install github.com/insightsengineering/locksmith@latest
 
 ## Usage
 
-`locksmith` is a command line utility, so after installing the binary in your `PATH`,simply run the
+`locksmith` is a command line utility, so after installing the binary in your `PATH`, simply run the
 following command to view its capabilities:
 
 ```bash

--- a/cmd/construct.go
+++ b/cmd/construct.go
@@ -24,7 +24,7 @@ import (
 // which should be included in the output renv.lock file,
 // based on the list of package descriptions, and information contained in the PACKAGES files.
 func ConstructOutputPackageList(packages []PackageDescription, packagesFiles map[string]PackagesFile,
-	repositoryList []string) []PackageDescription {
+	repositoryList []string, allowedMissingDependencyTypes []string) []PackageDescription {
 	var outputPackageList []PackageDescription
 	var fatalErrors string
 	// Add all input packages to output list, as the packages should be downloaded from git repositories.
@@ -44,7 +44,8 @@ func ConstructOutputPackageList(packages []PackageDescription, packagesFiles map
 					log.Info(p.Package, " → ", d.DependencyName, " (", d.DependencyType, ")")
 					ResolveDependenciesRecursively(
 						&outputPackageList, d.DependencyName, d.VersionOperator,
-						d.VersionValue, repositoryList, packagesFiles, 1, &fatalErrors,
+						d.VersionValue, d.DependencyType, allowedMissingDependencyTypes,
+						repositoryList, packagesFiles, 1, &fatalErrors,
 					)
 				}
 			}
@@ -61,8 +62,8 @@ func ConstructOutputPackageList(packages []PackageDescription, packagesFiles map
 // (later used to generate the renv.lock), or if the dependency should be downloaded from a package repository.
 // Repeats the process recursively for all dependencies not yet processed.
 func ResolveDependenciesRecursively(outputList *[]PackageDescription, name string, versionOperator string,
-	versionValue string, repositoryList []string, packagesFiles map[string]PackagesFile, recursionLevel int,
-	fatalErrors *string) {
+	versionValue string, dependencyType string, allowedMissingDependencyTypes []string,
+	repositoryList []string, packagesFiles map[string]PackagesFile, recursionLevel int, fatalErrors *string) {
 	var indentation string
 	for i := 0; i < recursionLevel; i++ {
 		indentation += "  "
@@ -103,7 +104,8 @@ func ResolveDependenciesRecursively(outputList *[]PackageDescription, name strin
 							)
 							ResolveDependenciesRecursively(
 								outputList, d.DependencyName, d.VersionOperator, d.VersionValue,
-								repositoryList, packagesFiles, recursionLevel+1, fatalErrors,
+								d.DependencyType, allowedMissingDependencyTypes, repositoryList,
+								packagesFiles, recursionLevel+1, fatalErrors,
 							)
 						}
 					}
@@ -115,9 +117,15 @@ func ResolveDependenciesRecursively(outputList *[]PackageDescription, name strin
 	}
 	var versionConstraint string
 	if versionOperator != "" && versionValue != "" {
-		versionConstraint = " in version " + versionOperator + " " + versionValue
+		versionConstraint = " (version " + versionOperator + " " + versionValue + ")"
 	}
-	*fatalErrors += "Could not find package " + name + versionConstraint + " in any of the repositories.\n"
+	message := "Could not find package " + name + versionConstraint + " in any of the repositories.\n"
+	if stringInSlice(dependencyType, allowedMissingDependencyTypes) {
+		log.Warn(indentation + message)
+	} else {
+		log.Error(indentation + message)
+		*fatalErrors += message
+	}
 }
 
 // CheckIfBasePackage checks whether the package should be treated as a base R package

--- a/cmd/construct_test.go
+++ b/cmd/construct_test.go
@@ -381,7 +381,7 @@ func Test_ConstructOutputPackageList(t *testing.T) {
 				"", "", "", "", "", "", "",
 			},
 		},
-		packagesFiles, repositoryList,
+		packagesFiles, repositoryList, []string{},
 	)
 	assert.Equal(t, outputPackageList,
 		[]PackageDescription{

--- a/cmd/construct_test.go
+++ b/cmd/construct_test.go
@@ -326,6 +326,12 @@ func Test_ConstructOutputPackageList(t *testing.T) {
 						"",
 						"",
 					},
+					{
+						"LinkingTo",
+						"nonExistentPackage",
+						"",
+						"",
+					},
 				},
 				"", "", "", "", "", "", "",
 			},
@@ -381,7 +387,10 @@ func Test_ConstructOutputPackageList(t *testing.T) {
 				"", "", "", "", "", "", "",
 			},
 		},
-		packagesFiles, repositoryList, []string{},
+		packagesFiles, repositoryList,
+		// Let the generation of renv.lock proceed, despite 'nonExistentPackage'
+		// (dependency type LinkingTo) not being found in any repository.
+		[]string{"LinkingTo"},
 	)
 	assert.Equal(t, outputPackageList,
 		[]PackageDescription{

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -46,7 +46,7 @@ func ParsePackagesFiles(repositoryPackageFiles map[string]string) map[string]Pac
 // with those fields/properties that are required for further processing.
 func ProcessPackagesFile(content string) PackagesFile {
 	var allPackages PackagesFile
-	// PACKAGES file in binary Windows repositories uses CRLF line endings.
+	// PACKAGES files in binary Windows repositories use CRLF line endings.
 	// Therefore, we first change them to LF line endings.
 	for _, lineGroup := range strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n\n") {
 		if lineGroup == "" {
@@ -57,8 +57,8 @@ func ProcessPackagesFile(content string) PackagesFile {
 		packageName := strings.ReplaceAll(firstLine, "Package: ", "")
 		cleaned := CleanDescriptionOrPackagesEntry(lineGroup, false)
 		if cleaned == "" {
-			// Entry pointing to a "Path:" subdirectory encountered.
-			// We skip such package entry altogether.
+			// Package entry pointing to a "Path:" subdirectory encountered.
+			// Such package entries are skipped altogether.
 			continue
 		}
 		packageMap := make(map[string]string)

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -46,6 +46,8 @@ func ParsePackagesFiles(repositoryPackageFiles map[string]string) map[string]Pac
 // with those fields/properties that are required for further processing.
 func ProcessPackagesFile(content string) PackagesFile {
 	var allPackages PackagesFile
+	// PACKAGES file in binary Windows repositories uses CRLF line endings.
+	// Therefore, we first change them to LF line endings.
 	for _, lineGroup := range strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n\n") {
 		if lineGroup == "" {
 			continue
@@ -53,7 +55,12 @@ func ProcessPackagesFile(content string) PackagesFile {
 		// Each lineGroup contains information about one package and is separated by an empty line.
 		firstLine := strings.Split(lineGroup, "\n")[0]
 		packageName := strings.ReplaceAll(firstLine, "Package: ", "")
-		cleaned := CleanDescriptionOrPackagesEntry(lineGroup)
+		cleaned := CleanDescriptionOrPackagesEntry(lineGroup, false)
+		if cleaned == "" {
+			// Entry pointing to a "Path:" subdirectory encountered.
+			// We skip such package entry altogether.
+			continue
+		}
 		packageMap := make(map[string]string)
 		err := yaml.Unmarshal([]byte(cleaned), &packageMap)
 		if err != nil {
@@ -75,7 +82,7 @@ func ProcessPackagesFile(content string) PackagesFile {
 // ProcessDescription reads a string containing DESCRIPTION file and returns a structure
 // with those fields/properties that are required for further processing.
 func ProcessDescription(description DescriptionFile, allPackages *[]PackageDescription) {
-	cleaned := CleanDescriptionOrPackagesEntry(description.Contents)
+	cleaned := CleanDescriptionOrPackagesEntry(description.Contents, true)
 	packageMap := make(map[string]string)
 	err := yaml.Unmarshal([]byte(cleaned), &packageMap)
 	checkError(err)
@@ -92,16 +99,24 @@ func ProcessDescription(description DescriptionFile, allPackages *[]PackageDescr
 	)
 }
 
-// CleanDescriptionOrPackagesEntry processes a multiline string representing information about one package
-// from PACKAGES file, or the whole contents of DESCRIPTION file. Removes newlines occurring within
-// filtered fields (which are predominantly fields containing lists of package dependencies).
-// Also removes fields which are not required for further processing.
-func CleanDescriptionOrPackagesEntry(description string) string {
+// CleanDescriptionOrPackagesEntry processes a multiline string representing information about one
+// package from PACKAGES file (if isDescription is false), or the whole contents of DESCRIPTION file
+// (if isDescription is true). Removes newlines occurring within filtered fields (which are
+// predominantly fields containing lists of package dependencies). Also removes fields which are not
+// required for further processing.
+func CleanDescriptionOrPackagesEntry(description string, isDescription bool) string {
 	lines := strings.Split(description, "\n")
 	filterFields := []string{"Package:", "Version:", "Depends:", "Imports:", "Suggests:", "LinkingTo:"}
 	outputContent := ""
 	processingFilteredField := false
 	for _, line := range lines {
+		if strings.HasPrefix(line, "Path:") && !isDescription {
+			// This means that the package is located in a subdirectory mentioned in this field.
+			// For example "Path: 4.4.0/Recommended" means that the package is located in
+			// "latest/src/contrib/4.4.0/Recommended/" subdirectory. We want to avoid these kinds of
+			// packages and prefer to download them from "latest/src/contrib/".
+			return ""
+		}
 		filteredFieldFound := false
 		// Check if we start processing any of the filtered fields.
 		for _, field := range filterFields {

--- a/cmd/testdata/PACKAGES
+++ b/cmd/testdata/PACKAGES
@@ -13,6 +13,15 @@ License: GPL-3
 MD5sum: bbb222333444555666
 NeedsCompilation: no
 
+Package: skippedPackage
+Version: 5.0.0
+Depends: R (>= 3.6.0)
+Imports: grDevices, graphics, grid, lattice, stats, utils
+License: GPL-3
+MD5sum: aaabbbccc999888777
+NeedsCompilation: no
+Path: 4.4.0/Recommended
+
 Package: somePackage3
 Version: 0.0.1
 Depends: R (>= 3.1.0)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -85,7 +85,7 @@ func ParseInput() ([]string, []string, map[string]string, []string) {
 	var allowedMissingDependencyTypes []string
 	if len(allowIncompleteRenvLock) > 0 {
 		allowedMissingDependencyTypes = strings.Split(allowIncompleteRenvLock, ",")
-		log.Debug("allowedMissingDependencyTypes =", allowedMissingDependencyTypes)
+		log.Debug("allowedMissingDependencyTypes = ", allowedMissingDependencyTypes)
 	}
 
 	outputRepositoryMap := make(map[string]string)
@@ -98,9 +98,9 @@ func ParseInput() ([]string, []string, map[string]string, []string) {
 		outputRepositoryMap[repository[0]] = repository[1]
 		outputRepositoryList = append(outputRepositoryList, repository[1])
 	}
-	log.Debug("inputPackageList =", packageList)
-	log.Debug("inputRepositoryList =", outputRepositoryList)
-	log.Debug("inputRepositoryMap =", outputRepositoryMap)
+	log.Debug("inputPackageList = ", packageList)
+	log.Debug("inputRepositoryList = ", outputRepositoryList)
+	log.Debug("inputRepositoryMap = ", outputRepositoryMap)
 	return packageList, outputRepositoryList, outputRepositoryMap, allowedMissingDependencyTypes
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -45,9 +45,10 @@ func stringInSlice(a string, list []string) bool {
 }
 
 // ParseInput parses CLI input parameters, and returns: list of package DESCRIPTION URLs,
-// list of package repository URLs (in descending priority order), and a map from package
-// repository alias (name) to the package repository URL.
-func ParseInput() ([]string, []string, map[string]string) {
+// list of package repository URLs (in descending priority order), a map from package
+// repository alias (name) to the package repository URL, and a list of allowed types
+// of missing dependencies.
+func ParseInput() ([]string, []string, map[string]string, []string) {
 	if len(inputPackageList) < 1 && len(inputPackages) == 0 {
 		log.Fatal(
 			"No packages specified. Please use the --inputPackageList flag ",
@@ -81,6 +82,12 @@ func ParseInput() ([]string, []string, map[string]string) {
 		repositoryList = inputRepositories
 	}
 
+	var allowedMissingDependencyTypes []string
+	if len(allowIncompleteRenvLock) > 0 {
+		allowedMissingDependencyTypes = strings.Split(allowIncompleteRenvLock, ",")
+		log.Debug("allowedMissingDependencyTypes =", allowedMissingDependencyTypes)
+	}
+
 	outputRepositoryMap := make(map[string]string)
 	var outputRepositoryList []string
 	for _, r := range repositoryList {
@@ -91,10 +98,10 @@ func ParseInput() ([]string, []string, map[string]string) {
 		outputRepositoryMap[repository[0]] = repository[1]
 		outputRepositoryList = append(outputRepositoryList, repository[1])
 	}
-	log.Debug("inputPackageList = ", packageList)
-	log.Debug("inputRepositoryList = ", outputRepositoryList)
-	log.Debug("inputRepositoryMap = ", outputRepositoryMap)
-	return packageList, outputRepositoryList, outputRepositoryMap
+	log.Debug("inputPackageList =", packageList)
+	log.Debug("inputRepositoryList =", outputRepositoryList)
+	log.Debug("inputRepositoryMap =", outputRepositoryMap)
+	return packageList, outputRepositoryList, outputRepositoryMap, allowedMissingDependencyTypes
 }
 
 func stringsToInts(input []string) []int {

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -25,7 +25,8 @@ import (
 func Test_ParseInput(t *testing.T) {
 	inputPackageList = "https://raw.githubusercontent.com/insightsengineering/tern/main/DESCRIPTION,https://raw.githubusercontent.com/insightsengineering/rlistings/v0.2.6/DESCRIPTION"
 	inputRepositoryList = "Repo1=https://repo1.example.com/repo1,Repo2=https://repo2.example.com/repo2,Repo3=https://repo3.example.com/repo3"
-	packageList, repositoryList, repositoryMap := ParseInput()
+	allowIncompleteRenvLock = "Imports,Depends,Suggests,LinkingTo"
+	packageList, repositoryList, repositoryMap, allowedMissingDependencyTypes := ParseInput()
 	assert.Equal(t, packageList, []string{
 		"https://raw.githubusercontent.com/insightsengineering/tern/main/DESCRIPTION",
 		"https://raw.githubusercontent.com/insightsengineering/rlistings/v0.2.6/DESCRIPTION",
@@ -39,5 +40,11 @@ func Test_ParseInput(t *testing.T) {
 		"Repo1": "https://repo1.example.com/repo1",
 		"Repo2": "https://repo2.example.com/repo2",
 		"Repo3": "https://repo3.example.com/repo3",
+	})
+	assert.Equal(t, allowedMissingDependencyTypes, []string{
+		"Imports",
+		"Depends",
+		"Suggests",
+		"LinkingTo",
 	})
 }


### PR DESCRIPTION
* Add a new `--allowIncompleteRenvLock` flag to let the `renv.lock` generation proceed even in case of dependencies missing from given repositories (the missing dependency types are customizable).
* Handle a situation where there are two entries in `PACKAGES` file for the same package but one of them points to a subdirectory specified in `Path:` field (e.g. `latest/src/contrib/4.4.0/Recommended/`).